### PR TITLE
Set caps lock key LED as a white caps lock indicator when enabled

### DIFF
--- a/keyboards/designedbygg/darkmage/keymaps/via/keymap.c
+++ b/keyboards/designedbygg/darkmage/keymaps/via/keymap.c
@@ -53,10 +53,10 @@ const uint16_t PROGMEM encoder_map[][1][2] = {
 };
 #endif
 
-#if defined(CAPS_LOCK_KEY)
+#if defined(CAPS_LOCK_LED_INDEX)
 bool rgb_matrix_indicators_advanced_user(uint8_t led_min, uint8_t led_max) {
     if (host_keyboard_led_state().caps_lock) {
-        RGB_MATRIX_INDICATOR_SET_COLOR(29, 255, 255, 255);
+        RGB_MATRIX_INDICATOR_SET_COLOR(CAPS_LOCK_LED_INDEX, RGB_WHITE);
     }
     return false;
 }

--- a/keyboards/designedbygg/darkmage/keymaps/via/keymap.c
+++ b/keyboards/designedbygg/darkmage/keymaps/via/keymap.c
@@ -52,3 +52,12 @@ const uint16_t PROGMEM encoder_map[][1][2] = {
     [1]   = {ENCODER_CCW_CW(RGB_VAD, RGB_VAI) },
 };
 #endif
+
+#if defined(CAPS_LOCK_KEY)
+bool rgb_matrix_indicators_advanced_user(uint8_t led_min, uint8_t led_max) {
+    if (host_keyboard_led_state().caps_lock) {
+        RGB_MATRIX_INDICATOR_SET_COLOR(29, 255, 255, 255);
+    }
+    return false;
+}
+#endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

See https://github.com/SonixQMK/qmk_firmware/pull/452

Even if there's no VIA specific code for now, vendor always ship its firmware with via profile.

<!--- Describe your changes in detail here. -->

## QMK Pull Request

https://github.com/SonixQMK/qmk_firmware/pull/452

<!--- VIA support for new keyboards MUST be in SonixQMK sn32_develop already -->

<!--- Add link to SonixQMK Pull Request here. -->

<!--- THIS IS MANDATORY. -->

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN SonixQMK sn32_develop ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is **MERGED** in SonixQMK sn32_develop already **(MANDATORY)**
- [x] I have tested this keyboard definition with firmware on a device.**(MANDATORY)**
- [ ] VIA keymap uses custom menus
- [ ] The Vendor ID is not `0xFEED`
