### PR TITLE
Redragon K582: Match right GUI key to left GUI key

### DIFF
--- a/keyboards/redragon/k582/keymaps/via/keymap.c
+++ b/keyboards/redragon/k582/keymaps/via/keymap.c
@@ -34,7 +34,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
                   KC_TAB,     KC_Q,       KC_W,       KC_E,    KC_R,       KC_T,    KC_Y,    KC_U,       KC_I,       KC_O,       KC_P,       KC_LBRC,    KC_RBRC,    KC_BSLS,    KC_DEL,     KC_END,     KC_PGDN,    KC_P7,      KC_P8,      KC_P9,      KC_PPLS,
                   KC_CAPS,    KC_A,       KC_S,       KC_D,    KC_F,       KC_G,    KC_H,    KC_J,       KC_K,       KC_L,       KC_SCLN,    KC_QUOT,    KC_ENT,      KC_P4,      KC_P5,      KC_P6,
                   KC_LSFT,    KC_Z,       KC_X,    KC_C,       KC_V,    KC_B,    KC_N,       KC_M,       KC_COMM,    KC_DOT,     KC_SLSH,      KC_RSFT,      KC_UP,     KC_P1,      KC_P2,      KC_P3,      KC_PENT,
-                  KC_LCTL,    KC_LGUI,    KC_LALT,    KC_SPC,  KC_RALT,    MO(_FL),   KC_APP,      KC_RCTL,      KC_LEFT,    KC_DOWN,    KC_RIGHT,      KC_P0,      KC_PDOT
+                  KC_LCTL,    KC_LGUI,    KC_LALT,    KC_SPC,  KC_RALT,    MO(_FL),   KC_RGUI,      KC_RCTL,      KC_LEFT,    KC_DOWN,    KC_RIGHT,      KC_P0,      KC_PDOT
     ),
     [_FL] = LAYOUT_fullsize_ansi(
                  QK_BOOT,      KC_MSEL,    KC_VOLD,    KC_VOLU, KC_MUTE,    KC_MSTP, KC_MPRV, KC_MPLY,    KC_MNXT,    KC_MAIL,    KC_WHOM,    KC_CALC,    RGB_TOG,    _______,    _______,     KC_SLEP,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
This matches the right GUI key to the left GUI key, changing `KC_APP` to `KC_RGUI`. This accomodates https://github.com/SonixQMK/qmk_firmware/pull/458.

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## QMK Pull Request

<!--- VIA support for new keyboards MUST be in SonixQMK sn32_develop already -->

<!--- Add link to SonixQMK Pull Request here. -->
https://github.com/SonixQMK/qmk_firmware/pull/458

<!--- THIS IS MANDATORY. -->

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN SonixQMK sn32_develop ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is **MERGED** in SonixQMK sn32_develop already **(MANDATORY)**
- [x] I have tested this keyboard definition with firmware on a device.**(MANDATORY)**
- [x] VIA keymap uses custom menus
- [x] The Vendor ID is not `0xFEED`
