### PR TITLE
designedbygg/redblade/rbfs: use the layer indicator led

### DIFF
--- a/keyboards/designedbygg/redblade/rbfs/keymaps/via/keymap.c
+++ b/keyboards/designedbygg/redblade/rbfs/keymaps/via/keymap.c
@@ -54,3 +54,17 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
         _______, _______, _______,                            _______,                            _______, _______, _______, _______,    RM_SATU, RM_HUEU, RM_SPDU,    _______,          _______
     ),
 };
+
+void keyboard_pre_init_user(void) {
+    gpio_set_pin_output(LED_FN_PIN);
+    gpio_write_pin_high(LED_FN_PIN);
+}
+
+layer_state_t layer_state_set_user(layer_state_t state) {
+    if (layer_state_cmp(state, 1)) {
+        gpio_write_pin_low(LED_FN_PIN);
+    } else {
+        gpio_write_pin_high(LED_FN_PIN);
+    }
+    return state;
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## QMK Pull Request

<!--- VIA support for new keyboards MUST be in SonixQMK sn32_develop already -->

<!--- Add link to SonixQMK Pull Request here. -->

<!--- THIS IS MANDATORY. -->

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN SonixQMK sn32_develop ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [ ] The VIA support for this keyboard is **MERGED** in SonixQMK sn32_develop already **(MANDATORY)**
- [ ] I have tested this keyboard definition with firmware on a device.**(MANDATORY)**
- [ ] VIA keymap uses custom menus
- [ ] The Vendor ID is not `0xFEED`
